### PR TITLE
Comments: rework config and verification

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -26,9 +26,36 @@ steam: cassidyjames # user/alias, no @
 twitter: "https://twitter.cassidyjames.com" # Full link to support archives
 unsplash: "@cassidyjames" # user including @
 
+# Mastodon-powered commenting. Values can be overridden in front-matter, e.g.
+# for multi-author blogs or guest posts.
 comments:
+  # Your Mastodon API host; this should be where you have an account
   host: mastodon.blaede.family
+  # Optional; vanity domain if configured; host will be used if omitted; UNIMPLEMENTED
+  domain: blaede.family
+  # Used to determine who the original/verified poster is; role may be expanded
+  # in the future (e.g. for moderation)
   username: cassidy
+  # Additional verified usernames in username@example.com format. If they are on
+  # the host listed above, OMIT the @example.com; UNIMPLEMENTED
+  verified:
+    - ahoneybunn@creatorstudio.space
+    - alatiera@mastodon.social
+    - alice@crab.garden
+    - brainblasted@crab.garden
+    - btkostner@mastodon.social
+    - jimmac@mastodon.social
+    - julian@fietkau.social
+    - katie
+    - lizkecso@mastodon.social
+    - Lobau@indieweb.social
+    - lucy
+    - micahilbery@mastodon.online
+    - nora
+    - razze@osna.social
+    - ryanleesipes@mastodon.social
+    - tammy
+    - tbernard@mastodon.social
 
 # Settings
 permalink: /blog/:title/

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -39,8 +39,8 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
   <p>Comment on this blog post by publicly replying to <a href="https://{{ host }}/@{{ username }}/{{ id }}">this Mastodon post</a> using a Mastodon or other ActivityPub/&ZeroWidthSpace;Fediverse account. Known non-private replies are displayed below.</p>
 
   <div id="comments-wrapper">
-    <p><small>No known comments, yet. Reply to <a href="https://{{ host }}/@{{ username }}/{{ .id }}">this Mastodon post</a> to add your own!</small></p>
-    <noscript><p>Loading comments relies on JavaScript. Try enabling JavaScript and reloading, or visit <a href="https://{{ host }}/@{{ username }}/{{ .id }}">the original post</a> on Mastodon.</p></noscript>
+    <p><small>No known comments, yet. Reply to <a href="https://{{ host }}/@{{ username }}/{{ id }}">this Mastodon post</a> to add your own!</small></p>
+    <noscript><p>Loading comments relies on JavaScript. Try enabling JavaScript and reloading, or visit <a href="https://{{ host }}/@{{ username }}/{{ id }}">the original post</a> on Mastodon.</p></noscript>
   </div>
 
   <script src="/js/purify.min.js"></script>
@@ -49,7 +49,7 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
 
     function loadComments() {
       let commentsWrapper = document.getElementById("comments-wrapper");
-      let postUrl = "https://{{ host }}/api/v1/statuses/{{ .id }}";
+      let postUrl = "https://{{ host }}/api/v1/statuses/{{ id }}";
 
       fetch(postUrl)
       .then(function(response) {

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -2,13 +2,45 @@
 Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750bb53b9f0f6f28399ce4d21785a3bb7d22/_includes/fediverse_comments.html
 -->
 
+{% if include.host %}
+  {% assign host = include.host %}
+{% elsif page.comments.host %}
+  {% assign host = page.comments.host %}
+{% else %}
+  {% assign host = site.comments.host %}
+{% endif %}
+
+{% if include.domain %}
+  {% assign domain = include.domain %}
+{% elsif page.comments.domain %}
+  {% assign domain = page.comments.domain %}
+{% elsif site.comments.domain %}
+  {% assign domain = site.comments.domain %}
+{% else %}
+  {% assign domain = host %}
+{% endif %}
+
+{% if include.username %}
+  {% assign username = include.username %}
+{% elsif page.comments.username %}
+  {% assign username = page.comments.username %}
+{% else %}
+  {% assign username = site.comments.username %}
+{% endif %}
+
+{% if include.id %}
+  {% assign id = include.id %}
+{% else %}
+  {% assign id = page.comments.id %}
+{% endif %}
+
 <section id="comments" class="comments">
   <h2>Comments</h2>
-  <p>Comment on this blog post by publicly replying to <a href="https://{{ site.comments.host }}/@{{ site.comments.username }}/{{ page.comments.id }}">this Mastodon post</a> using a Mastodon or other ActivityPub/&ZeroWidthSpace;Fediverse account. Known non-private replies are displayed below.</p>
+  <p>Comment on this blog post by publicly replying to <a href="https://{{ host }}/@{{ username }}/{{ id }}">this Mastodon post</a> using a Mastodon or other ActivityPub/&ZeroWidthSpace;Fediverse account. Known non-private replies are displayed below.</p>
 
   <div id="comments-wrapper">
-    <p><small>No known comments, yet. Reply to <a href="https://{{ site.comments.host }}/@{{ site.comments.username }}/{{ page.comments.id }}">this Mastodon post</a> to add your own!</small></p>
-    <noscript><p>Loading comments relies on JavaScript. Try enabling JavaScript and reloading, or visit <a href="https://{{ site.comments.host }}/@{{ site.comments.username }}/{{ page.comments.id }}">the original post</a> on Mastodon.</p></noscript>
+    <p><small>No known comments, yet. Reply to <a href="https://{{ host }}/@{{ username }}/{{ .id }}">this Mastodon post</a> to add your own!</small></p>
+    <noscript><p>Loading comments relies on JavaScript. Try enabling JavaScript and reloading, or visit <a href="https://{{ host }}/@{{ username }}/{{ .id }}">the original post</a> on Mastodon.</p></noscript>
   </div>
 
   <script src="/js/purify.min.js"></script>
@@ -17,7 +49,7 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
 
     function loadComments() {
       let commentsWrapper = document.getElementById("comments-wrapper");
-      let postUrl = "https://{{ site.comments.host }}/api/v1/statuses/{{ page.comments.id }}";
+      let postUrl = "https://{{ host }}/api/v1/statuses/{{ .id }}";
 
       fetch(postUrl)
       .then(function(response) {
@@ -51,8 +83,8 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
               if( status.account.acct.includes("@") ) {
                 instance = status.account.acct.split("@")[1];
               } else {
-                instance = "blaede.family";
-                verified = true;
+                instance = "{{ domain }}";
+                /* verified = true; */
               }
 
               status.content = emojify(status.content, status.emojis);

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -184,14 +184,32 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
 
               if(op === true) {
                 comment.classList.add("op");
-                avatar.classList.add("op");
-                instanceBadge.classList.add("op");
-              }
 
-              if(verified === true) {
+                avatar.classList.add("op");
+                avatar.setAttribute(
+                  "title",
+                  "Blog post author; " + avatar.getAttribute("title")
+                );
+
+                instanceBadge.classList.add("op");
+                instanceBadge.setAttribute(
+                  "title",
+                  "Blog post author: " + instanceBadge.getAttribute("title")
+                );
+              } else if(verified === true) {
                 comment.classList.add("verified");
+
                 avatar.classList.add("verified");
+                avatar.setAttribute(
+                  "title",
+                  avatar.getAttribute("title") + " (verified by site owner)"
+                );
+
                 instanceBadge.classList.add("verified");
+                instanceBadge.setAttribute(
+                  "title",
+                  instanceBadge.getAttribute("title") + " (verified by site owner)"
+                );
               }
 
               commentsWrapper.innerHTML += DOMPurify.sanitize(comment.outerHTML);

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -34,6 +34,12 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
   {% assign id = page.comments.id %}
 {% endif %}
 
+{% if site.comments.verified %}
+  {% assign verified = site.comments.verified | jsonify %}
+{% else %}
+  {% assign verified = "[]" %}
+{% endif %}
+
 <section id="comments" class="comments">
   <h2>Comments</h2>
   <p>Comment on this blog post by publicly replying to <a href="https://{{ host }}/@{{ username }}/{{ id }}">this Mastodon post</a> using a Mastodon or other ActivityPub/&ZeroWidthSpace;Fediverse account. Known non-private replies are displayed below.</p>
@@ -55,7 +61,7 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
       .then(function(response) {
         return response.json();
       })
-      .then(function(op) {
+      .then(function(status) {
         fetch(postUrl + "/context")
         .then(function(response) {
           return response.json();
@@ -68,7 +74,7 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
             descendants.length > 0
           ) {
             commentsWrapper.innerHTML = "";
-            descendants.unshift(op);
+            descendants.unshift(status);
 
             data['descendants'].forEach(function(status) {
               if( status.account.display_name.length > 0 ) {
@@ -79,12 +85,20 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
               };
 
               let instance = "";
-              let verified = false;
               if( status.account.acct.includes("@") ) {
                 instance = status.account.acct.split("@")[1];
               } else {
                 instance = "{{ domain }}";
-                /* verified = true; */
+              }
+
+              let op = false;
+              if( status.account.acct == "{{ username }}" ) {
+                op = true;
+              }
+
+              let verified = false;
+              if( {{ verified }}.includes(status.account.acct) ) {
+                verified = true;
               }
 
               status.content = emojify(status.content, status.emojis);
@@ -102,12 +116,12 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
               avatarPicture.appendChild(avatarSource);
               avatarPicture.appendChild(avatarImg);
 
-              let avatarLink = document.createElement("a");
-              avatarLink.className = "avatar-link";
-              avatarLink.setAttribute("href", status.account.url);
-              avatarLink.setAttribute("rel", "external nofollow");
-              avatarLink.setAttribute("title", `View profile at @${ status.account.username }@${ instance }`);
-              avatarLink.appendChild(avatarPicture);
+              let avatar = document.createElement("a");
+              avatar.className = "avatar-link";
+              avatar.setAttribute("href", status.account.url);
+              avatar.setAttribute("rel", "external nofollow");
+              avatar.setAttribute("title", `View profile at @${ status.account.username }@${ instance }`);
+              avatar.appendChild(avatarPicture);
 
               let instanceBadge = document.createElement("a");
               instanceBadge.className = "instance";
@@ -162,14 +176,22 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
               comment.className = "comment";
               comment.setAttribute("itemprop", "comment");
               comment.setAttribute("itemtype", "http://schema.org/Comment");
-              comment.appendChild(avatarLink);
+              comment.appendChild(avatar);
               comment.appendChild(header);
               comment.appendChild(timestamp);
               comment.appendChild(main);
               comment.appendChild(interactions);
 
+              if(op === true) {
+                comment.classList.add("op");
+                avatar.classList.add("op");
+                instanceBadge.classList.add("op");
+              }
+
               if(verified === true) {
                 comment.classList.add("verified");
+                avatar.classList.add("verified");
+                instanceBadge.classList.add("verified");
               }
 
               commentsWrapper.innerHTML += DOMPurify.sanitize(comment.outerHTML);

--- a/_sass/_comments.scss
+++ b/_sass/_comments.scss
@@ -22,6 +22,23 @@ section#comments {
         height: 100%;
         width: 100%;
       }
+
+      &.op::after {
+        background-color: var(--secondary-accent-color);
+        border-radius: 50%;
+        bottom: -0.25rem;
+        color: var(--secondary-accent-contrast);
+        content: "✓";
+        display: block;
+        font-size: 1.25rem;
+        font-weight: bold;
+        height: 1.5rem;
+        line-height: 1.5rem;
+        position: absolute;
+        right: -0.25rem;
+        text-align: center;
+        width: 1.5rem;
+      }
     }
 
     .author {
@@ -42,6 +59,18 @@ section#comments {
         &:hover {
           opacity: 0.8;
           text-decoration: none;
+        }
+
+        &.op {
+          background-color: var(--secondary-accent-color);
+          color: var(--secondary-accent-contrast);
+
+          &::before {
+            content: "✓";
+            font-weight: bold;
+            margin-inline-end: 0.25em;
+            margin-inline-start: -0.25em;
+          }
         }
       }
     }
@@ -100,37 +129,6 @@ section#comments {
 
     .ellipsis::after {
       content: "…";
-    }
-
-    &.verified {
-     .avatar-link::after {
-        background-color: var(--secondary-accent-color);
-        border-radius: 50%;
-        bottom: -0.25rem;
-        color: var(--secondary-accent-contrast);
-        content: "✓";
-        display: block;
-        font-size: 1.25rem;
-        font-weight: bold;
-        height: 1.5rem;
-        line-height: 1.5rem;
-        position: absolute;
-        right: -0.25rem;
-        text-align: center;
-        width: 1.5rem;
-      }
-
-      .instance {
-        background-color: var(--secondary-accent-color);
-        color: var(--secondary-accent-contrast);
-
-        &::before {
-          content: "✓";
-          font-weight: bold;
-          margin-inline-end: 0.25em;
-          margin-inline-start: -0.25em;
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
This PR adds support for quite a few things:

- a new `domain` option for vanity domains (like `@cassidy@blaede.family` which lives on `mastodon.blaede.family`); if omitted, defaults to `host`

- `host`, `domain`, and `username` may each be specified in the site config, in the page frontmatter, or directly in the include to better support multi-author blogs

- `id` may now be specified directly in the include

- a new `site.comments.verified` list which adds the appropriate style classes (currently unused in my styles)

- a new `op` style class for the user that matches `username`@`domain`, e.g. the blog post author

Fixes #43; cc @ahoneybun