### PR TITLE
Comments: Add support for authentication token

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -32,13 +32,23 @@ unsplash: "@cassidyjames" # user including @
 comments:
   # Your Mastodon API host; this should be where you have an account
   host: mastodon.blaede.family
-  # Optional; vanity domain if configured; host will be used if omitted; UNIMPLEMENTED
+
+  # Optional; vanity domain if configured; host will be used if omitted
   domain: blaede.family
+
   # Used to determine who the original/verified poster is; role may be expanded
   # in the future (e.g. for moderation)
   username: cassidy
+
+  # Optional; required to fetch more than 60 replies to any given blog post.
+  # Application access token with read:statuses scope; NOTE: IF INCLUDED, ANYONE
+  # WILL BE ABLE TO READ THE ASSOCIATED ACCOUNT'S PRIVATE STATUSES. It is highly
+  # recommended to use a dedicated bot/API account to create an application with
+  # scope read:statuses.
+  token: GTFBn-YO_QYIU4rc_RHKjuAHE_2RTv0LfpFcvlRLk0g
+
   # Additional verified usernames in username@example.com format. If they are on
-  # the host listed above, OMIT the @example.com; UNIMPLEMENTED
+  # the host listed above, OMIT the @example.com
   verified:
     - ahoneybunn@creatorstudio.space
     - alatiera@mastodon.social

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -103,10 +103,7 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
             commentsWrapper.innerHTML = "";
             descendants.unshift(status);
 
-            let count = 0;
             data['descendants'].forEach(function(status) {
-              console.log(count + ": " + status.account.acct + " " + status.id + " " + status.favourited);
-              count++;
               if( status.account.display_name.length > 0 ) {
                 status.account.display_name = escapeHtml(status.account.display_name);
                 status.account.display_name = emojify(

--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -28,6 +28,14 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
   {% assign username = site.comments.username %}
 {% endif %}
 
+{% if include.token %}
+  {% assign token = include.token %}
+{% elsif page.comments.token %}
+  {% assign token = page.comments.token %}
+{% else %}
+  {% assign token = site.comments.token %}
+{% endif %}
+
 {% if include.id %}
   {% assign id = include.id %}
 {% else %}
@@ -51,22 +59,41 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
 
   <script src="/js/purify.min.js"></script>
   <script>
-    loadComments ();
+    loadComments();
 
     function loadComments() {
-      let commentsWrapper = document.getElementById("comments-wrapper");
-      let statusUrl = "https://{{ host }}/api/v1/statuses/{{ id }}";
+      const HOST = "{{ host }}";
+      const DOMAIN = "{{ domain }}";
+      const USERNAME = "{{ username }}";
+      const TOKEN = "{{ token }}";
+      const VERIFIED = {{ verified }};
+      const ID = "{{ id }}";
 
-      fetch(statusUrl)
-      .then(function(response) {
+      const STATUS_URL = `https://${ HOST }/api/v1/statuses/${ ID }`;
+
+      const REQUEST_HEADERS = new Headers();
+      if(TOKEN != ""){
+        REQUEST_HEADERS.append("Authorization", "Bearer " + TOKEN);
+      }
+
+      const requestOptions = {
+        method: "GET",
+        headers: REQUEST_HEADERS,
+        mode: "cors",
+        cache: "default",
+      };
+
+      const STATUS_REQUEST = new Request(STATUS_URL, requestOptions);
+      const CONTEXT_REQUEST = new Request(STATUS_URL + "/context", requestOptions);
+
+      let commentsWrapper = document.getElementById("comments-wrapper");
+
+      fetch(STATUS_REQUEST).then((response) => {
         return response.json();
-      })
-      .then(function(status) {
-        fetch(statusUrl + "/context")
-        .then(function(response) {
+      }).then((status) => {
+        fetch(CONTEXT_REQUEST).then((response) => {
           return response.json();
-        })
-        .then(function(data) {
+        }).then((data) => {
           let descendants = data['descendants'];
           if(
             descendants &&
@@ -76,7 +103,10 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
             commentsWrapper.innerHTML = "";
             descendants.unshift(status);
 
+            let count = 0;
             data['descendants'].forEach(function(status) {
+              console.log(count + ": " + status.account.acct + " " + status.id + " " + status.favourited);
+              count++;
               if( status.account.display_name.length > 0 ) {
                 status.account.display_name = escapeHtml(status.account.display_name);
                 status.account.display_name = emojify(
@@ -91,16 +121,16 @@ Inspired by https://codeberg.org/jwildeboer/jwildeboersource/src/commit/45f9750b
               if( status.account.acct.includes("@") ) {
                 instance = status.account.acct.split("@")[1];
               } else {
-                instance = "{{ domain }}";
+                instance = DOMAIN;
               }
 
               let op = false;
-              if( status.account.acct == "{{ username }}" ) {
+              if( status.account.acct == USERNAME ) {
                 op = true;
               }
 
               let verified = false;
-              if( {{ verified }}.includes(status.account.acct) ) {
+              if( VERIFIED.includes(status.account.acct) ) {
                 verified = true;
               }
 


### PR DESCRIPTION
If provided, a Mastodon application access token with the `read:statuses` scope will enable fetching more than 60 replies to a post (see: https://github.com/mastodon/mastodon/issues/25892)

NOTE: IF INCLUDED, ANYONE WILL BE ABLE TO READ THE ASSOCIATED ACCOUNT'S PRIVATE STATUSES. It is highly recommended to use a dedicated bot/API account to create an application with scope `read:statuses`.

This PR also cleans up a bit of the JavaScript, leaning on defining constants up front to make it more easily portable to other platforms/static site generators.